### PR TITLE
Improve workqueue throughput

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   set(OPT_FLAGS -O0 -g)
 else()
-  set(OPT_FLAGS -O3)
+  set(OPT_FLAGS -O3 -g)
 endif()
 
 if (FRAK_SAN_TYPE)

--- a/frak_args.c
+++ b/frak_args.c
@@ -31,7 +31,6 @@ static struct arg_enum_opt palette_enum_opts[] = {
 };
 
 static struct arg_enum_opt design_enum_opts[] = {
-    {.option = "noise", .value = frak_design_noise},
     {.option = "mandlebrot", .value = frak_design_mandlebrot},
     {.option = "mand", .value = frak_design_mandlebrot},
     {.option = NULL, .value = 0},
@@ -204,6 +203,9 @@ static int color_sort(void const* a, void const* b) {
 }
 
 char* frak_args_validate(frak_args_t args) {
+  if (args->design == frak_design_default) {
+    args->design = frak_design_mandlebrot;
+  }
   if (args->palette == frak_palette_black_and_white &&
       args->design == frak_design_mandlebrot) {
     return strdup(
@@ -215,9 +217,6 @@ char* frak_args_validate(frak_args_t args) {
     } else if (args->design != frak_design_mandlebrot) {
       return strdup("Cannot specify --max-iter without --design mandlebrot");
     }
-  }
-  if (args->design == frak_design_default) {
-    args->design = frak_design_noise;
   }
   if (args->max_iteration == 0) {
     args->max_iteration = 1000;

--- a/frak_args.c
+++ b/frak_args.c
@@ -16,10 +16,6 @@ void frak_usage(int code) {
 }
 
 static struct arg_enum_opt palette_enum_opts[] = {
-    {.option = "b", .value = frak_palette_black_and_white},
-    {.option = "bw", .value = frak_palette_black_and_white},
-    {.option = "bilevel", .value = frak_palette_black_and_white},
-    {.option = "blackwhite", .value = frak_palette_black_and_white},
     {.option = "g", .value = frak_palette_gray},
     {.option = "gray", .value = frak_palette_gray},
     {.option = "grey", .value = frak_palette_gray},
@@ -206,11 +202,6 @@ char* frak_args_validate(frak_args_t args) {
   if (args->design == frak_design_default) {
     args->design = frak_design_mandlebrot;
   }
-  if (args->palette == frak_palette_black_and_white &&
-      args->design == frak_design_mandlebrot) {
-    return strdup(
-        "Mandlebrots cannot be generated with a black & white palette");
-  }
   if (args->max_iteration != 0) {
     if (args->design == frak_design_default) {
       args->design = frak_design_mandlebrot;
@@ -230,7 +221,7 @@ char* frak_args_validate(frak_args_t args) {
     }
   }
   if (args->palette == frak_palette_default) {
-    args->palette = frak_palette_black_and_white;
+    args->palette = frak_palette_gray;
   } else if (args->palette == frak_palette_custom) {
     if (!args->colors) {
       return strdup("Must specify --color with --palette custom");

--- a/frak_args.c
+++ b/frak_args.c
@@ -172,6 +172,12 @@ struct arg_spec const* const frak_arg_specs = (struct arg_spec[]){
      .parser = bool_parser,
      .offset = offsetof(struct frak_args, print_help),
      .help = "Show this help page"},
+    {.flag = "--worker-cache-size",
+     .takes_arg = true,
+     .required = false,
+     .parser = pu32_parser,
+     .offset = offsetof(struct frak_args, worker_cache_size),
+     .help = "The number of pixels to place into a single work item"},
     {.flag = NULL},
 };
 
@@ -188,6 +194,7 @@ void frak_args_init(frak_args_t args) {
   args->palette_only = false;
   args->worker_count = 0;
   args->print_help = false;
+  args->worker_cache_size = 0;
 }
 
 static int color_sort(void const* a, void const* b) {
@@ -245,6 +252,9 @@ char* frak_args_validate(frak_args_t args) {
           "Can only in place change palette if color palette is"
           " being used (--palette color/custom)");
     }
+  }
+  if (!args->worker_cache_size) {
+    args->worker_cache_size = (uint32_t)-1;
   }
   return NULL;
 }

--- a/frak_args.c
+++ b/frak_args.c
@@ -56,7 +56,7 @@ static bool cp_num_bnd(const char** iter, char* buf, unsigned cnt, char c) {
     return false;
   }
   liter++;
-  buf[1] = '\0';
+  buf[0] = '\0';
   *iter = liter;
   return true;
 }

--- a/frak_args.h
+++ b/frak_args.h
@@ -15,7 +15,6 @@ enum frak_palette {
 };
 
 enum frak_design {
-  frak_design_noise = 0,
   frak_design_mandlebrot = 1,
   frak_design_default = 2,
 };

--- a/frak_args.h
+++ b/frak_args.h
@@ -45,6 +45,7 @@ typedef struct frak_args {
   bool palette_only;
   uint32_t worker_count;
   bool print_help;
+  uint32_t worker_cache_size;
 } * frak_args_t;
 
 extern struct arg_spec const* const frak_arg_specs;

--- a/frakl/queue.c
+++ b/frakl/queue.c
@@ -84,6 +84,16 @@ bool queue_is_empty(queue_t q) {
   return atomic_load(&q->head) == atomic_load(&q->tail);
 }
 
+void queue_dump(queue_t q) {
+  printf("Dumping queue %p\n", q);
+  uintptr_t head = q->head;
+  uintptr_t tail = q->tail;
+  uintptr_t cap_mask = q->cap_mask;
+  for (uintptr_t i = tail; i != head; i = ((i + 1) & cap_mask)) {
+    printf("  At %lu (%p): %p\n", i, &q->cells[i], q->cells[i].data);
+  }
+}
+
 unsigned queue_get_length(queue_t q) {
   uintptr_t head = atomic_load(&q->head);
   uintptr_t tail = atomic_load(&q->tail);

--- a/frakl/queue.c
+++ b/frakl/queue.c
@@ -60,15 +60,14 @@ void queue_push(queue_t q, void* data) {
 unsigned queue_pop_n(queue_t q, unsigned n, void* results[]) {
   const uintptr_t head = atomic_load(&q->head);
   uintptr_t tail = atomic_load(&q->tail);
-  if (tail == head) {
-    bzero(results, sizeof(void*) * n);
-    return 0;
-  }
   const uintptr_t cap_mask = q->cap_mask;
   const uintptr_t cap = cap_mask + 1;
   uintptr_t len;
   uintptr_t new_tail;
   do {
+    if (tail == head) {
+      return 0;
+    }
     len = head > tail ? head - tail : cap + head - tail;
     new_tail = (tail + (n < len ? n : len)) & cap_mask;
   } while (!atomic_compare_exchange_weak(&q->tail, &tail, new_tail));

--- a/frakl/queue.h
+++ b/frakl/queue.h
@@ -17,12 +17,11 @@ void queue_destroy(queue_t q);
 
 void queue_push(queue_t q, void* data);
 
-void queue_pop_n(queue_t q, unsigned n, void* results[]);
+unsigned queue_pop_n(queue_t q, unsigned n, void* results[]);
 
 static inline void* queue_pop(queue_t q) {
   void* buffer[1];
-  queue_pop_n(q, 1, buffer);
-  return buffer[0];
+  return queue_pop_n(q, 1, buffer) == 1 ? buffer[0] : NULL;
 }
 
 void queue_dump(queue_t q);

--- a/frakl/queue.h
+++ b/frakl/queue.h
@@ -17,7 +17,15 @@ void queue_destroy(queue_t q);
 
 void queue_push(queue_t q, void* data);
 
-void* queue_pop(queue_t q);
+void queue_pop_n(queue_t q, unsigned n, void* results[]);
+
+static inline void* queue_pop(queue_t q) {
+  void* buffer[1];
+  queue_pop_n(q, 1, buffer);
+  return buffer[0];
+}
+
+void queue_dump(queue_t q);
 
 bool queue_is_empty(queue_t q);
 

--- a/frakl/wq.c
+++ b/frakl/wq.c
@@ -12,8 +12,8 @@ struct wq {
   char* name;
   queue_t queue;
   size_t worker_count;
-  size_t initial_cache_size;
-  bool use_local_cache;
+  uint32_t local_cache_size;
+  bool computed_cache_size;
   pthread_t* workers;
   void* ctx;
 };
@@ -26,7 +26,6 @@ struct wq_item {
 static size_t get_reasonable_worker_count(void) {
   return 4 * sysconf(_SC_NPROCESSORS_ONLN) / 3;
 }
-
 wq_t wq_create(const char* name, size_t worker_count, size_t queue_cap_shift) {
   wq_t res = malloc(sizeof(struct wq));
   res->name = strdup(name);
@@ -37,12 +36,12 @@ wq_t wq_create(const char* name, size_t worker_count, size_t queue_cap_shift) {
   res->worker_count = worker_count;
   res->workers = NULL;
   res->ctx = NULL;
-  res->use_local_cache = true;
+  res->local_cache_size = (uint32_t)-1;
   return res;
 }
 
-void wq_set_use_local_cache(wq_t wq, bool use_cache) {
-  wq->use_local_cache = use_cache;
+void wq_set_worker_cache_size(wq_t wq, uint32_t size) {
+  wq->local_cache_size = size;
 }
 
 const char* wq_get_name(wq_t wq) { return wq->name; }
@@ -54,44 +53,29 @@ void wq_push(wq_t wq, wq_cb_t cb, void* work) {
   queue_push(wq->queue, item);
 }
 
-static struct wq_item** create_worker_cache(queue_t q,
-                                            size_t initial_cache_size) {
-  if (!initial_cache_size) {
-    return NULL;
-  }
-  struct wq_item** res = calloc(initial_cache_size, sizeof(struct wq_item*));
-  queue_pop_n(q, initial_cache_size, (void**)res);
-  return res;
-}
-
-static __attribute__((noinline)) void wq_local_cache_worker(
-    struct wq_item** iter, struct wq_item* const* const end, void* ctx) {
-  struct wq_item* item;
-  while (iter != end) {
-    item = *iter++;
-    if (item) {
-      item->cb(item->work, ctx);
-      free(item);
-    }
-  }
-}
-
 static void* wq_worker(wq_t wq) {
   queue_t q = wq->queue;
   void* ctx = wq->ctx;
 
-  const size_t initial_cache_size = wq->initial_cache_size;
-  struct wq_item** local_cache = create_worker_cache(q, initial_cache_size);
-  if (local_cache) {
-    wq_local_cache_worker(local_cache, local_cache + initial_cache_size, ctx);
-    free(local_cache);
-  }
+  const uint32_t cache_size = wq->local_cache_size ?: 10;
+  struct wq_item** cache = calloc(cache_size, sizeof(struct wq_item*));
 
   struct wq_item* item;
-  while ((item = queue_pop(q)) != NULL) {
-    item->cb(item->work, ctx);
-    free(item);
-  }
+  struct wq_item* const* end = cache + cache_size;
+  struct wq_item** iter;
+  do {
+    unsigned n = queue_pop_n(q, cache_size, (void**)cache);
+    if (!n) {
+      break;
+    }
+    iter = cache;
+    end = iter + n;
+    do {
+      item = *iter;
+      item->cb(item->work, ctx);
+    } while (++iter != end);
+  } while (true);
+  free(cache);
   return NULL;
 }
 
@@ -102,9 +86,12 @@ void wq_start(wq_t wq, void* ctx) {
   const size_t worker_count = wq->worker_count;
   wq->workers = calloc(worker_count, sizeof(pthread_t));
   wq->ctx = ctx;
-  wq->initial_cache_size =
-      wq->use_local_cache ? queue_get_length(wq->queue) / (2 * worker_count)
-                          : 0;
+  if (wq->local_cache_size == (uint32_t)-1) {
+    wq->local_cache_size = queue_get_length(wq->queue) / (8 * worker_count);
+    wq->computed_cache_size = true;
+  } else {
+    wq->computed_cache_size = false;
+  }
   for (size_t i = 0; i < worker_count; i++) {
     pthread_create(&wq->workers[i], NULL, (void*)&wq_worker, wq);
   }
@@ -117,6 +104,10 @@ void wq_wait(wq_t wq) {
   }
   free(wq->workers);
   wq->workers = NULL;
+  if (wq->computed_cache_size) {
+    wq->computed_cache_size = false;
+    wq->local_cache_size = (uint32_t)-1;
+  }
 }
 
 void wq_destroy(wq_t wq) {

--- a/frakl/wq.c
+++ b/frakl/wq.c
@@ -12,6 +12,8 @@ struct wq {
   char* name;
   queue_t queue;
   size_t worker_count;
+  size_t initial_cache_size;
+  bool use_local_cache;
   pthread_t* workers;
   void* ctx;
 };
@@ -35,7 +37,12 @@ wq_t wq_create(const char* name, size_t worker_count, size_t queue_cap_shift) {
   res->worker_count = worker_count;
   res->workers = NULL;
   res->ctx = NULL;
+  res->use_local_cache = true;
   return res;
+}
+
+void wq_set_use_local_cache(wq_t wq, bool use_cache) {
+  wq->use_local_cache = use_cache;
 }
 
 const char* wq_get_name(wq_t wq) { return wq->name; }
@@ -47,9 +54,39 @@ void wq_push(wq_t wq, wq_cb_t cb, void* work) {
   queue_push(wq->queue, item);
 }
 
+static struct wq_item** create_worker_cache(queue_t q,
+                                            size_t initial_cache_size) {
+  if (!initial_cache_size) {
+    return NULL;
+  }
+  struct wq_item** res = calloc(initial_cache_size, sizeof(struct wq_item*));
+  queue_pop_n(q, initial_cache_size, (void**)res);
+  return res;
+}
+
+static __attribute__((noinline)) void wq_local_cache_worker(
+    struct wq_item** iter, struct wq_item* const* const end, void* ctx) {
+  struct wq_item* item;
+  while (iter != end) {
+    item = *iter++;
+    if (item) {
+      item->cb(item->work, ctx);
+      free(item);
+    }
+  }
+}
+
 static void* wq_worker(wq_t wq) {
   queue_t q = wq->queue;
   void* ctx = wq->ctx;
+
+  const size_t initial_cache_size = wq->initial_cache_size;
+  struct wq_item** local_cache = create_worker_cache(q, initial_cache_size);
+  if (local_cache) {
+    wq_local_cache_worker(local_cache, local_cache + initial_cache_size, ctx);
+    free(local_cache);
+  }
+
   struct wq_item* item;
   while ((item = queue_pop(q)) != NULL) {
     item->cb(item->work, ctx);
@@ -65,6 +102,9 @@ void wq_start(wq_t wq, void* ctx) {
   const size_t worker_count = wq->worker_count;
   wq->workers = calloc(worker_count, sizeof(pthread_t));
   wq->ctx = ctx;
+  wq->initial_cache_size =
+      wq->use_local_cache ? queue_get_length(wq->queue) / (2 * worker_count)
+                          : 0;
   for (size_t i = 0; i < worker_count; i++) {
     pthread_create(&wq->workers[i], NULL, (void*)&wq_worker, wq);
   }

--- a/frakl/wq.h
+++ b/frakl/wq.h
@@ -12,7 +12,7 @@ typedef void (*wq_cb_t)(void* work, void* ctx);
 // Pass worker_count = 0 for default
 wq_t wq_create(const char* name, size_t worker_count, size_t queue_cap_shift);
 
-void wq_set_use_local_cache(wq_t wq, bool use_cache);
+void wq_set_worker_cache_size(wq_t wq, uint32_t size);
 
 const char* wq_get_name(wq_t wq);
 

--- a/frakl/wq.h
+++ b/frakl/wq.h
@@ -7,16 +7,17 @@
 
 struct wq;
 typedef struct wq* wq_t;
-typedef void (*wq_cb_t)(void* work, void* ctx);
+typedef void (*wq_cb_t)(void** work, unsigned n, void* ctx);
 
 // Pass worker_count = 0 for default
-wq_t wq_create(const char* name, size_t worker_count, size_t queue_cap_shift);
+wq_t wq_create(const char* name, wq_cb_t cb, size_t worker_count,
+               size_t queue_cap_shift);
 
 void wq_set_worker_cache_size(wq_t wq, uint32_t size);
 
 const char* wq_get_name(wq_t wq);
 
-void wq_push(wq_t wq, wq_cb_t cb, void* work);
+void wq_push(wq_t wq, void* work);
 
 void wq_start(wq_t wq, void* ctx);
 

--- a/frakl/wq.h
+++ b/frakl/wq.h
@@ -12,6 +12,8 @@ typedef void (*wq_cb_t)(void* work, void* ctx);
 // Pass worker_count = 0 for default
 wq_t wq_create(const char* name, size_t worker_count, size_t queue_cap_shift);
 
+void wq_set_use_local_cache(wq_t wq, bool use_cache);
+
 const char* wq_get_name(wq_t wq);
 
 void wq_push(wq_t wq, wq_cb_t cb, void* work);

--- a/frakl/wq.h
+++ b/frakl/wq.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 struct wq;

--- a/main.c
+++ b/main.c
@@ -39,15 +39,6 @@ static void fill_random(void* buffer, size_t len) {
 #endif
 }
 
-static uint8_t random_pixel(uint32_t a, uint32_t b, uint32_t c, uint32_t d) {
-  (void)a, (void)b, (void)c, (void)d;
-#if __APPLE__
-  return arc4random();
-#else
-  return random();
-#endif
-}
-
 static uint32_t max_iteration = 1000;
 
 // c = x + iy
@@ -78,12 +69,10 @@ static uint8_t mandlebrot_pixel(uint32_t column, uint32_t row, uint32_t width,
 struct pixel_worker_ctx {
   struct frak_args const* const args;
   void* buffer;
-  uint8_t (*callback)(uint32_t column, uint32_t row, uint32_t width,
-                      uint32_t height);
 };
 
-static void pixel_worker(void** pixels, unsigned n,
-                         struct pixel_worker_ctx* ctx) {
+static void mandlebrot_worker(void** pixels, unsigned n,
+                              struct pixel_worker_ctx* ctx) {
   struct frak_args const* const args = ctx->args;
 
   const uint32_t width = args->width;
@@ -95,7 +84,7 @@ static void pixel_worker(void** pixels, unsigned n,
     uint32_t i = (uint32_t)(pixel - ctx->buffer);
     uint32_t row = i / width;
     uint32_t column = i % width;
-    *(uint8_t*)pixel = ctx->callback(column, row, width, height);
+    *(uint8_t*)pixel = mandlebrot_pixel(column, row, width, height);
   } while (++iter != end);
 }
 
@@ -264,21 +253,8 @@ int main(int argc, const char* argv[]) {
         .args = &args,
         .buffer = data,
     };
-    switch (args.design) {
-      case frak_design_mandlebrot:
-        ctx.callback = mandlebrot_pixel;
-        break;
-      default:
-        fprintf(stderr, "Unexpected design %u, defaulting to noise\n",
-                args.design);
-        /* fallthrough */
-      case frak_design_noise:
-        ctx.callback = (void*)random_pixel;
-        break;
-    }
-
     const uint32_t work_count = args.width * args.height;
-    wq_t wq = wq_create("frak", (void*)pixel_worker, args.worker_count,
+    wq_t wq = wq_create("frak", (void*)mandlebrot_worker, args.worker_count,
                         32 - __builtin_clz(work_count));
     wq_set_worker_cache_size(wq, args.worker_cache_size);
     for (uint32_t i = 0; i < work_count; i++) {

--- a/main.c
+++ b/main.c
@@ -167,16 +167,12 @@ static inline void tiff_spec_init_from_frak_args(tiff_spec_t spec,
         } while ((++to_fcol) != end_fcol);
       }
     } break;
-    case frak_palette_gray:
-      spec->type = tiff_gray;
-      spec->palette = NULL;
-      break;
     default:
       fprintf(stderr, "Unknown palette type %d, defaulting to bilevel\n",
               args->palette);
       /* fallthrough */
-    case frak_palette_black_and_white:
-      spec->type = tiff_bilevel;
+    case frak_palette_gray:
+      spec->type = tiff_gray;
       spec->palette = NULL;
       break;
   }

--- a/tests/driver.c
+++ b/tests/driver.c
@@ -1,12 +1,13 @@
 // Copywrite (c) 2019 Dan Zimmerman
 
 #include <stdio.h>
+#include <unistd.h>
 
 #include "tests.h"
 
 int main(int argc, const char* argv[]) {
   (void)argc;
   (void)argv;
-  printf("Running frak tests...\n");
-  return run_tests() ? 0 : 1;
+  printf("Running frak tests... %d\n", getpid());
+  return run_tests(argc < 2 ? NULL : argv[1]) ? 0 : 1;
 }

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -7,6 +7,7 @@
 #include <setjmp.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 typedef struct test {
   const char* name;
@@ -55,7 +56,7 @@ void register_test(const char* name, test_cb_t cb, bool expect_fail,
   new_test->line = line;
 }
 
-bool run_tests(void) {
+bool run_tests(const char* filter) {
   volatile bool any_fail = false;
   struct test const* volatile iter = g_test_list.tests;
   struct test const* const volatile end = iter + g_test_list.length;
@@ -66,6 +67,9 @@ bool run_tests(void) {
   volatile struct timespec tstart;
   volatile struct timespec tend;
   do {
+    if (filter && strcmp(filter, iter->name) != 0) {
+      continue;
+    }
     g_failure.check = iter->name;
     g_failure.file = iter->file;
     g_failure.line = iter->line;

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -8,7 +8,7 @@ typedef void (*test_cb_t)(void);
 
 void register_test(const char* name, test_cb_t test, bool expect_fail,
                    const char* file, int line);
-bool run_tests(void);
+bool run_tests(const char* filter);
 void fail(const char* check, const char* file, int line);
 
 #define TEST_(name, expect_fail)                                         \

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdio.h>
 
 typedef void (*test_cb_t)(void);
 

--- a/tests/wq.c
+++ b/tests/wq.c
@@ -20,13 +20,14 @@ static void computer(uint8_t* cell, uint8_t* base) {
   *cell = x;
 }
 
-TEST(Workqueue) {
+static void _test_wq_internal(bool use_local_cache) {
   uint8_t buffer[512];
   struct timespec start;
   struct timespec concurrent;
   struct timespec serial;
 
   wq_t wq = wq_create("test", 0, 0);
+  wq_set_use_local_cache(wq, use_local_cache);
   for (unsigned i = 0; i < sizeof(buffer); i++) {
     wq_push(wq, (void*)computer, buffer + i);
   }
@@ -69,3 +70,7 @@ TEST(Workqueue) {
          concurrent.tv_sec * 1000 + concurrent.tv_nsec / 1000000);
   wq_destroy(wq);
 }
+
+TEST(WorkqueueNoLocalCache) { _test_wq_internal(false); }
+
+TEST(WorkqueueLocalCache) { _test_wq_internal(true); }

--- a/tests/wq.c
+++ b/tests/wq.c
@@ -26,8 +26,8 @@ static void _test_wq_internal(bool use_local_cache) {
   struct timespec concurrent;
   struct timespec serial;
 
-  wq_t wq = wq_create("test", 0, 0);
-  wq_set_use_local_cache(wq, use_local_cache);
+  wq_t wq = wq_create("test", 0, 32 - __builtin_clz(sizeof(buffer)));
+  wq_set_worker_cache_size(wq, use_local_cache ? (uint32_t)-1 : 1);
   for (unsigned i = 0; i < sizeof(buffer); i++) {
     wq_push(wq, (void*)computer, buffer + i);
   }


### PR DESCRIPTION
On my laptop computation of a 10000x10000 mandlebrot goes from ~75s -> ~15s (1/5th the time!). Note: my laptop is running an Intel M3 dual core chip with hyperthreading enabled (i.e. this is a slow computer, it clocks in slower than my phone even)