### PR TITLE
Add --randomize flag to try and improve the workload spread

### DIFF
--- a/frak_args.c
+++ b/frak_args.c
@@ -173,6 +173,12 @@ struct arg_spec const* const frak_arg_specs = (struct arg_spec[]){
      .parser = pu32_parser,
      .offset = offsetof(struct frak_args, worker_cache_size),
      .help = "The number of pixels to place into a single work item"},
+    {.flag = "--randomize",
+     .takes_arg = false,
+     .required = false,
+     .parser = bool_parser,
+     .offset = offsetof(struct frak_args, randomize),
+     .help = "Attempt to randomize the order that pixels are computed in"},
     {.flag = "--stats",
      .takes_arg = false,
      .required = false,
@@ -196,6 +202,7 @@ void frak_args_init(frak_args_t args) {
   args->worker_count = 0;
   args->print_help = false;
   args->worker_cache_size = 0;
+  args->randomize = false;
   args->stats = false;
 }
 

--- a/frak_args.c
+++ b/frak_args.c
@@ -173,6 +173,12 @@ struct arg_spec const* const frak_arg_specs = (struct arg_spec[]){
      .parser = pu32_parser,
      .offset = offsetof(struct frak_args, worker_cache_size),
      .help = "The number of pixels to place into a single work item"},
+    {.flag = "--stats",
+     .takes_arg = false,
+     .required = false,
+     .parser = bool_parser,
+     .offset = offsetof(struct frak_args, stats),
+     .help = "Print stats about each phase of running"},
     {.flag = NULL},
 };
 
@@ -190,6 +196,7 @@ void frak_args_init(frak_args_t args) {
   args->worker_count = 0;
   args->print_help = false;
   args->worker_cache_size = 0;
+  args->stats = false;
 }
 
 static int color_sort(void const* a, void const* b) {

--- a/frak_args.h
+++ b/frak_args.h
@@ -45,6 +45,7 @@ typedef struct frak_args {
   uint32_t worker_count;
   bool print_help;
   uint32_t worker_cache_size;
+  bool randomize;
   bool stats;
 } * frak_args_t;
 

--- a/frak_args.h
+++ b/frak_args.h
@@ -45,6 +45,7 @@ typedef struct frak_args {
   uint32_t worker_count;
   bool print_help;
   uint32_t worker_cache_size;
+  bool stats;
 } * frak_args_t;
 
 extern struct arg_spec const* const frak_arg_specs;

--- a/main.c
+++ b/main.c
@@ -40,6 +40,17 @@ static void fill_random(void* buffer, size_t len) {
 #endif
 }
 
+static uint32_t give_me_random(uint32_t max) {
+#if __APPLE__
+  return arc4random_uniform(max);
+#else
+  // Yeah yeah, this isn't uniform. I did an interview question once
+  // implementing properly uniform random numbers for arbitrary ranges...
+  // The implementation isn't fun...
+  return random() % max;
+#endif
+}
+
 static uint32_t max_iteration = 1000;
 
 // c = x + iy
@@ -277,8 +288,22 @@ int main(int argc, const char* argv[]) {
                         32 - __builtin_clz(work_count));
     wq_set_worker_cache_size(wq, args.worker_cache_size);
 
-    for (uint32_t i = 0; i < work_count; i++) {
-      wq_push(wq, data + i);
+    if (args.randomize) {
+      uint32_t* is = calloc(work_count, sizeof(uint32_t));
+      for (uint32_t i = 0; i < work_count; i++) {
+        is[i] = i;
+      }
+      for (uint32_t i = 0; i < work_count; i++) {
+        is[i] = give_me_random(work_count - i);
+      }
+      for (uint32_t i = 0; i < work_count; i++) {
+        wq_push(wq, data + is[i]);
+      }
+      free(is);
+    } else {
+      for (uint32_t i = 0; i < work_count; i++) {
+        wq_push(wq, data + i);
+      }
     }
     if (args.stats) {
       clock_gettime(CLOCK_MONOTONIC_RAW, &init_queue);

--- a/main.c
+++ b/main.c
@@ -16,6 +16,7 @@
 
 #include "frak_args.h"
 #include "frakl/tiff.h"
+#include "frakl/time_utils.h"
 #include "frakl/wq.h"
 
 static void fill_random(void* buffer, size_t len) {
@@ -188,6 +189,14 @@ int main(int argc, const char* argv[]) {
   size_t len;
   int o_flags = 0;
 
+  struct timespec start;
+  struct timespec init;
+  struct timespec mmap_img;
+  struct timespec meta;
+  struct timespec init_queue;
+  struct timespec compute_data;
+
+  clock_gettime(CLOCK_MONOTONIC_RAW, &start);
   frak_args_init(&args);
   char* err = parse_frak_args(&args, argc, argv);
   if (err || args.print_help) {
@@ -228,12 +237,18 @@ int main(int argc, const char* argv[]) {
       goto out;
     }
   }
+  if (args.stats) {
+    clock_gettime(CLOCK_MONOTONIC_RAW, &init);
+  }
 
   buf = mmap(NULL, len, PROT_WRITE | PROT_READ, MAP_FILE | MAP_SHARED, fd, 0);
   if (!buf || buf == MAP_FAILED) {
     perror("mmap");
     rc = 1;
     goto out;
+  }
+  if (args.stats) {
+    clock_gettime(CLOCK_MONOTONIC_RAW, &mmap_img);
   }
 
   if (args.palette_only) {
@@ -242,8 +257,16 @@ int main(int argc, const char* argv[]) {
       fprintf(stderr, "Failed to update color palette: %s\n", err);
       rc = 1;
     }
+    if (args.stats) {
+      clock_gettime(CLOCK_MONOTONIC_RAW, &meta);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &init_queue);
+      clock_gettime(CLOCK_MONOTONIC_RAW, &compute_data);
+    }
   } else {
     data = tiff_spec_write_metadata(&spec, buf);
+    if (args.stats) {
+      clock_gettime(CLOCK_MONOTONIC_RAW, &meta);
+    }
 
     struct pixel_worker_ctx ctx = {
         .args = &args,
@@ -253,11 +276,19 @@ int main(int argc, const char* argv[]) {
     wq_t wq = wq_create("frak", (void*)mandlebrot_worker, args.worker_count,
                         32 - __builtin_clz(work_count));
     wq_set_worker_cache_size(wq, args.worker_cache_size);
+
     for (uint32_t i = 0; i < work_count; i++) {
       wq_push(wq, data + i);
     }
+    if (args.stats) {
+      clock_gettime(CLOCK_MONOTONIC_RAW, &init_queue);
+    }
+
     wq_start(wq, &ctx);
     wq_wait(wq);
+    if (args.stats) {
+      clock_gettime(CLOCK_MONOTONIC_RAW, &compute_data);
+    }
     wq_destroy(wq);
   }
 
@@ -273,6 +304,20 @@ out:
   }
   if (spec.palette) {
     free(spec.palette);
+  }
+  if (args.stats) {
+    timespec_minus(&compute_data, &init_queue);
+    timespec_minus(&init_queue, &meta);
+    timespec_minus(&meta, &mmap_img);
+    timespec_minus(&mmap_img, &init);
+    timespec_minus(&init, &start);
+
+#define milli(ts) (ts.tv_sec * 1000 + ts.tv_nsec / 1000000)
+    printf(
+        "Timing:\n  init: %3ld\n  mmap: %3ld\n  meta: %3ld\n  qini: %3ld\n "
+        "comp: %3ld\n",
+        milli(init), milli(mmap_img), milli(meta), milli(init_queue),
+        milli(compute_data));
   }
   return rc;
 }


### PR DESCRIPTION
In theory one of the bottlenecks is that workloads are very asymmetric. In order to combat this lets randomize the data. The unfortunate part, at least on my laptop, is that randomization overhead makes it not worth it to randomize on a 10000x10000 image. It's still good to have in the codebase for now so we can:
- improve randomization speed
- use for larger images where qini time isn't so dominating