### PR TITLE
Change queue/wq's create function to take max capacity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ asan
 lsan
 tsan
 msan
+ubsan
 
 ### CMake Patch ###
 # External projects

--- a/frak_args.c
+++ b/frak_args.c
@@ -198,6 +198,11 @@ static int color_sort(void const* a, void const* b) {
 }
 
 char* frak_args_validate(frak_args_t args) {
+  if (args->width * arg->height >= UINT32_MAX) {
+    return strdup(
+        "Image requested is too large, only images up until 2^32-1 pixels "
+        "large are supported right now");
+  }
   if (args->design == frak_design_default) {
     args->design = frak_design_mandlebrot;
   }

--- a/frak_args.c
+++ b/frak_args.c
@@ -198,7 +198,7 @@ static int color_sort(void const* a, void const* b) {
 }
 
 char* frak_args_validate(frak_args_t args) {
-  if (args->width * arg->height >= UINT32_MAX) {
+  if (args->width * args->height >= UINT32_MAX) {
     return strdup(
         "Image requested is too large, only images up until 2^32-1 pixels "
         "large are supported right now");

--- a/frakl/queue.c
+++ b/frakl/queue.c
@@ -1,6 +1,7 @@
 // Copywrite (c) 2019 Dan Zimmerman
 
 #include "queue.h"
+#include "utils.h"
 
 #include <assert.h>
 #include <stdatomic.h>
@@ -21,11 +22,9 @@ struct queue {
   struct q_cell cells[];
 };
 
-queue_t queue_create(uint8_t cap_pow) {
-  if (cap_pow == 0 || cap_pow > 31) {
-    cap_pow = 16;
-  }
-  size_t cap = 1 << cap_pow;
+queue_t queue_create(uintptr_t max_cap) {
+  // Due to our implementation we need one extra empty cell.
+  const uintptr_t cap = round_to_next_power_of_two(max_cap + 1);
   queue_t res = malloc(sizeof(struct queue) + cap * sizeof(struct q_cell));
   res->cap_mask = cap - 1;
   atomic_init(&res->head, 0);

--- a/frakl/queue.h
+++ b/frakl/queue.h
@@ -9,9 +9,7 @@
 struct queue;
 typedef struct queue* queue_t;
 
-// cap_pow is the capacity as specified as a power of 2, i.e. for a capacity of
-// 4 the caller should pass 2.
-queue_t queue_create(uint8_t cap_pow);
+queue_t queue_create(uintptr_t max_cap);
 
 void queue_destroy(queue_t q);
 

--- a/frakl/utils.h
+++ b/frakl/utils.h
@@ -1,0 +1,27 @@
+// Copywrite (c) 2019 Dan Zimmerman
+
+#pragma once
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+#define __round_clz __builtin_clzll
+#else
+#define __round_clz __builtin_clz
+#endif
+
+static inline uintptr_t round_to_next_power_of_two(uintptr_t x) {
+  if (!x) {
+    return 0;
+  }
+  const unsigned max_bit_set = sizeof(uintptr_t) * 8 - __round_clz(x) - 1;
+  assert(max_bit_set < sizeof(uintptr_t) * 8);
+  const uintptr_t max_bit_value = 1 << max_bit_set;
+  if (max_bit_value == x) {
+    return max_bit_value;
+  } else {
+    return max_bit_value * 2;
+  }
+}

--- a/frakl/utils.h
+++ b/frakl/utils.h
@@ -16,9 +16,9 @@ static inline uintptr_t round_to_next_power_of_two(uintptr_t x) {
   if (!x) {
     return 0;
   }
-  const unsigned max_bit_set = sizeof(uintptr_t) * 8 - __round_clz(x) - 1;
+  const uintptr_t max_bit_set = sizeof(uintptr_t) * 8 - __round_clz(x) - 1;
   assert(max_bit_set < sizeof(uintptr_t) * 8);
-  const uintptr_t max_bit_value = 1 << max_bit_set;
+  const uintptr_t max_bit_value = (uintptr_t)1 << max_bit_set;
   if (max_bit_value == x) {
     return max_bit_value;
   } else {

--- a/frakl/wq.c
+++ b/frakl/wq.c
@@ -22,8 +22,9 @@ struct wq {
 static size_t get_reasonable_worker_count(void) {
   return 4 * sysconf(_SC_NPROCESSORS_ONLN) / 3;
 }
+
 wq_t wq_create(const char* name, wq_cb_t cb, size_t worker_count,
-               size_t queue_cap_shift) {
+               uintptr_t queue_cap_shift) {
   wq_t res = malloc(sizeof(struct wq));
   res->name = strdup(name);
   res->queue = queue_create(queue_cap_shift);

--- a/frakl/wq.h
+++ b/frakl/wq.h
@@ -12,7 +12,7 @@ typedef void (*wq_cb_t)(void** work, unsigned n, void* ctx);
 
 // Pass worker_count = 0 for default
 wq_t wq_create(const char* name, wq_cb_t cb, size_t worker_count,
-               size_t queue_cap_shift);
+               size_t queue_max_cap);
 
 void wq_set_worker_cache_size(wq_t wq, uint32_t size);
 

--- a/frakl/wq.h
+++ b/frakl/wq.h
@@ -12,7 +12,7 @@ typedef void (*wq_cb_t)(void** work, unsigned n, void* ctx);
 
 // Pass worker_count = 0 for default
 wq_t wq_create(const char* name, wq_cb_t cb, size_t worker_count,
-               size_t queue_max_cap);
+               uintptr_t queue_max_cap);
 
 void wq_set_worker_cache_size(wq_t wq, uint32_t size);
 

--- a/main.c
+++ b/main.c
@@ -271,7 +271,7 @@ int main(int argc, const char* argv[]) {
         .args = &args,
         .buffer = data,
     };
-    const uint32_t work_count = args.width * args.height;
+    const uintptr_t work_count = args.width * args.height;
     wq_t wq = wq_create("frak", (void*)mandlebrot_worker, args.worker_count,
                         work_count);
     wq_set_worker_cache_size(wq, args.worker_cache_size);

--- a/main.c
+++ b/main.c
@@ -273,7 +273,7 @@ int main(int argc, const char* argv[]) {
     };
     const uint32_t work_count = args.width * args.height;
     wq_t wq = wq_create("frak", (void*)mandlebrot_worker, args.worker_count,
-                        32 - __builtin_clz(work_count));
+                        work_count);
     wq_set_worker_cache_size(wq, args.worker_cache_size);
     wq_push_n(wq, work_count, NULL);
     if (args.stats) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.8.1)
 
 project(frak_tests VERSION 0.1)
 
-set(FRAK_TESTS_SRC driver.c tests.c tests_tests.c queue.c wq.c args.c)
+set(FRAK_TESTS_SRC driver.c tests.c tests_tests.c queue.c wq.c args.c utils.c)
 add_executable(frak_tests EXCLUDE_FROM_ALL ${FRAK_TESTS_SRC})
 add_dependencies(frak_tests frakl)
 target_compile_options(frak_tests PRIVATE ${FRAK_CFLAGS})

--- a/tests/queue.c
+++ b/tests/queue.c
@@ -7,7 +7,8 @@
 #include "tests.h"
 
 TEST(Queue) {
-  queue_t q = queue_create(2);
+  queue_t q = queue_create(3);
+  EXPECT_EQ(queue_get_capacity(q), 3);
   EXPECT_EQ(queue_get_length(q), 0);
   EXPECT_TRUE(queue_is_empty(q));
 
@@ -97,7 +98,7 @@ TEST(Queue) {
 TEST(QueuePopN) {
   void* buffer[3];
 
-  queue_t q = queue_create(2);
+  queue_t q = queue_create(3);
   queue_push(q, (void*)0x1);
   queue_push(q, (void*)0x2);
 
@@ -141,7 +142,7 @@ TEST(QueuePushN) {
   void* pusher[3];
   void* buffer[3];
 
-  queue_t q = queue_create(2);
+  queue_t q = queue_create(3);
   pusher[0] = (void*)0x1;
   pusher[1] = (void*)0x2;
   EXPECT_EQ(queue_push_n(q, 2, pusher), 2);
@@ -208,7 +209,7 @@ static void* queue_popper(queue_t q) {
 }
 
 TEST(QueueMultiThread) {
-  queue_t q = queue_create(17);
+  queue_t q = queue_create(70000);
   pthread_t t[5];
   for (unsigned i = 0; i < 5; i++) {
     EXPECT_EQ(pthread_create(&t[i], NULL, (void*)queue_pusher, q), 0);

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -14,4 +14,5 @@ TEST(RoundToNextPowerOfTwo) {
   EXPECT_EQ(round_to_next_power_of_two(32), 32);
   EXPECT_EQ(round_to_next_power_of_two(33), 64);
   EXPECT_EQ(round_to_next_power_of_two(70000), 131072);
+  EXPECT_EQ(round_to_next_power_of_two(2500000001), 0x100000000);
 }

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -1,0 +1,17 @@
+// Copywrite (c) 2019 Dan Zimmerman
+
+#include <frakl/utils.h>
+
+#include "tests.h"
+
+TEST(RoundToNextPowerOfTwo) {
+  EXPECT_EQ(round_to_next_power_of_two(0), 0);
+  EXPECT_EQ(round_to_next_power_of_two(1), 1);
+  EXPECT_EQ(round_to_next_power_of_two(2), 2);
+  EXPECT_EQ(round_to_next_power_of_two(3), 4);
+  EXPECT_EQ(round_to_next_power_of_two(4), 4);
+  EXPECT_EQ(round_to_next_power_of_two(10), 16);
+  EXPECT_EQ(round_to_next_power_of_two(32), 32);
+  EXPECT_EQ(round_to_next_power_of_two(33), 64);
+  EXPECT_EQ(round_to_next_power_of_two(70000), 131072);
+}

--- a/tests/wq.c
+++ b/tests/wq.c
@@ -27,8 +27,7 @@ static void _test_wq_internal(bool use_local_cache) {
   struct timespec concurrent;
   struct timespec serial;
 
-  wq_t wq =
-      wq_create("test", (void*)computer, 0, 32 - __builtin_clz(sizeof(buffer)));
+  wq_t wq = wq_create("test", (void*)computer, 0, 512);
   wq_set_worker_cache_size(wq, use_local_cache ? (uint32_t)-1 : 1);
 
   void* q_items[sizeof(buffer) / 2];


### PR DESCRIPTION
Before it awkwardly took max capacity shifts putting the onus on the caller to compute the correct shift. The new interface makes a lot more sense: give me the max number of items you'll ever need.

This fixes a crash on my work iMac Pro as well (bad integer computation leading to a huge amount of memory allocated)